### PR TITLE
SWF-4517 : remove prefix project name 'eXo Add-on:: ' to exclude it from Sonar supported addons

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
   <artifactId>wai-sample</artifactId>
   <version>4.4.x-SNAPSHOT</version>
   <packaging>pom</packaging>
-  <name>eXo Add-on:: Web Accessibility Initiative (WAI) sample</name>
+  <name>Web Accessibility Initiative (WAI) sample</name>
   <scm>
     <connection>scm:git:git://github.com/exoplatform/wai-sample.git</connection>
     <developerConnection>scm:git:git@github.com:exoplatform/wai-sample.git</developerConnection>


### PR DESCRIPTION
Remove prefix project name 'eXo Add-on:: ' to exclude it from Sonar supported addons.